### PR TITLE
Add macOS disaster compatibility

### DIFF
--- a/disaster.el
+++ b/disaster.el
@@ -82,7 +82,8 @@
   :group 'disaster
   :type 'string)
 
-(defcustom disaster-objdump "objdump -d -M att -Sl --no-show-raw-insn"
+(defcustom disaster-objdump (concat (if (eq system-type 'darwin) "gobjdump" "objdump")
+                                    " -d -M att -Sl --no-show-raw-insn")
   "The command name and flags for running objdump."
   :group 'disaster
   :type 'string)


### PR DESCRIPTION
From issue #12 I gather that we can have a quick check so that there is no need to do static linking of files in macOS.

I'm happy to hear your feedback on this.