### PR TITLE
Fixed the condition for what command to run

### DIFF
--- a/disaster.el
+++ b/disaster.el
@@ -150,19 +150,17 @@ is used."
 			 file))
 	     (rel-obj (concat (file-name-sans-extension rel-file) ".o"))
 	     (obj-file (concat make-root rel-obj))
-             (cc (if make-root
-                     (if (equal cwd make-root)
-                         (format "make %s %s" disaster-make-flags (shell-quote-argument rel-obj))
-                       (format "make %s -C %s %s"
-                               disaster-make-flags make-root
-                               rel-obj))
-                   (if (string-match "\\.c[cp]p?$" file)
-                       (format "%s %s -g -c -o %s %s"
-                               disaster-cxx disaster-cxxflags
-                               (shell-quote-argument obj-file) (shell-quote-argument file))
-                     (format "%s %s -g -c -o %s %s"
-                             disaster-cc disaster-cflags
-                             (shell-quote-argument obj-file) (shell-quote-argument file)))))
+	     (cc (cond ((file-exists-p "Makefile")
+			(format "make %s %s" disaster-make-flags (shell-quote-argument rel-obj)))
+		       ((file-exists-p "../Makefile")
+			(format "make %s -C %s %s" disaster-make-flags make-root rel-obj))
+                       ((string-match "\\.c[cp]p?$" file)
+			(format "%s %s -g -c -o %s %s"
+				disaster-cxx disaster-cxxflags
+				(shell-quote-argument obj-file) (shell-quote-argument file)))
+		       (t (format "%s %s -g -c -o %s %s"
+				  disaster-cc disaster-cflags
+				  (shell-quote-argument obj-file) (shell-quote-argument file)))))
              (dump (format "%s %s" disaster-objdump
 			   (shell-quote-argument (concat make-root rel-obj))))
              (line-text (buffer-substring-no-properties


### PR DESCRIPTION
The logic that's used to determine what compilation command to run doesn't seem quite right. If you try executing `disaster` in a git repository which doesn't have a makefile, it will still run `make -k <file>`. That's because `disaster-find-build-root` is basically the identity function in disguise and will return its argument no matter what (because `disaster-find-build-root-functions` is `nil`). That means that the condition `(if make-root ...)` is really `(if proj-root ...)` which is not the same condition. Doesn't it seem much simpler to just directly check whether the current directory has a Makefile (and also whether the parent directory has a Makefile)?

i.e.

```
	     (cond ((file-exists-p "Makefile")
			(format "make %s %s" disaster-make-flags (shell-quote-argument rel-obj)))
		       ((file-exists-p "../Makefile")
			(format "make %s -C %s %s" disaster-make-flags make-root rel-obj))
			; etc
```