### PR TITLE
M1 Mac chip fix

### DIFF
--- a/disaster.el
+++ b/disaster.el
@@ -84,13 +84,11 @@
 (require 'json)
 (require 'vc)
 
-(defun disaster--is-mac-m1? ()
-  "Optimize for Mac M1 if true.
-If system type = darwin and cpu type = arm64 add apple m1 flag.
-Otherwise return the classic native flag."
-  (if ((lambda () (and (eq system-type 'darwin)
-                       (string= "arm64"
-                                (string-trim (shell-command-to-string "uname -m"))))))
+(defun disaster--arch-flags ()
+  "Select the right flags depending on the right architecture."
+  (if ((lambda () "Optimize for M1 family if true"
+         (and (eq system-type 'darwin)
+              (string= "arm64" (string-trim (shell-command-to-string "uname -m"))))))
       "-mcpu=apple-m1"
     "-march=native"))
 
@@ -126,20 +124,20 @@ Otherwise return the classic native flag."
   :type 'string)
 
 (defcustom disaster-cflags (or (getenv "CFLAGS")
-                               (disaster--is-mac-m1?))
+                               (disaster--arch-flags))
   "Command line options to use when compiling C."
   :group 'disaster
   :type 'string)
 
 (defcustom disaster-cxxflags (or (getenv "CXXFLAGS")
-                                 (disaster--is-mac-m1?))
+                                 (disaster--arch-flags))
   "Command line options to use when compiling C++.!"
   :group 'disaster
   :type 'string)
 
 
 (defcustom disaster-fortranflags (or (getenv "FORTRANFLAGS")
-                                     (disaster--is-mac-m1?))
+                                     (disaster--arch-flags))
   "Command line options to use when compiling Fortran."
   :group 'disaster
   :type 'string)

--- a/disaster.el
+++ b/disaster.el
@@ -84,6 +84,17 @@
 (require 'json)
 (require 'vc)
 
+(defun disaster--is-mac-m1? ()
+  "Optimize for Mac M1 if true.
+If system type = darwin and cpu type = arm64 add apple m1 flag.
+Otherwise return the classic native flag."
+  (if (and (eq system-type 'darwin)
+           (lambda ()
+             (string= "arm64\n"
+                      (shell-command-to-string "uname -m"))))
+      "-mcpu=apple-m1"
+    "-march=native"))
+
 (defgroup disaster nil
   "Disassemble C/C++ under cursor (Works best with Clang)."
   :prefix "disaster-"
@@ -116,27 +127,26 @@
   :type 'string)
 
 (defcustom disaster-cflags (or (getenv "CFLAGS")
-                               "-march=native")
+                               (disaster--is-mac-m1?))
   "Command line options to use when compiling C."
   :group 'disaster
   :type 'string)
 
 (defcustom disaster-cxxflags (or (getenv "CXXFLAGS")
-                                 "-march=native")
+                                 (disaster--is-mac-m1?))
   "Command line options to use when compiling C++.!"
   :group 'disaster
   :type 'string)
 
 
 (defcustom disaster-fortranflags (or (getenv "FORTRANFLAGS")
-                                     "-march=native")
+                                     (disaster--is-mac-m1?))
   "Command line options to use when compiling Fortran."
   :group 'disaster
   :type 'string)
 
 (defcustom disaster-objdump
-  (concat (if (eq system-type 'darwin) "gobjdump" "objdump")
-          " -d -M att -Sl --no-show-raw-insn")
+  "objdump -d -M att -Sl --no-show-raw-insn"
   "The command name and flags for running objdump."
   :group 'disaster
   :type 'string)

--- a/disaster.el
+++ b/disaster.el
@@ -84,11 +84,14 @@
 (require 'json)
 (require 'vc)
 
+(defun disaster--is-m1? ()
+  "Identify Mac M1 chips."
+  (and (eq system-type 'darwin)
+       (string= "aarch64" (car (split-string system-configuration "-")))))
+
 (defun disaster--arch-flags ()
   "Select the right flags depending on the right architecture."
-  (if ((lambda () "Optimize for M1 family if true"
-         (and (eq system-type 'darwin)
-              (string= "arm64" (string-trim (shell-command-to-string "uname -m"))))))
+  (if (disaster--is-m1?)
       "-mcpu=apple-m1"
     "-march=native"))
 
@@ -143,7 +146,11 @@
   :type 'string)
 
 (defcustom disaster-objdump
-  "objdump -d -M att -Sl --no-show-raw-insn"
+  (concat (if (and (eq system-type 'darwin)
+                   (not (disaster--is-m1?)))
+              "gobjdump"
+            "objdump")
+          " -d -M att -Sl --no-show-raw-insn")
   "The command name and flags for running objdump."
   :group 'disaster
   :type 'string)

--- a/disaster.el
+++ b/disaster.el
@@ -88,10 +88,9 @@
   "Optimize for Mac M1 if true.
 If system type = darwin and cpu type = arm64 add apple m1 flag.
 Otherwise return the classic native flag."
-  (if (and (eq system-type 'darwin)
-           (lambda ()
-             (string= "arm64\n"
-                      (shell-command-to-string "uname -m"))))
+  (if ((lambda () (and (eq system-type 'darwin)
+                       (string= "arm64"
+                                (string-trim (shell-command-to-string "uname -m"))))))
       "-mcpu=apple-m1"
     "-march=native"))
 


### PR DESCRIPTION
Hi @abougouffa, I created this pull request to close the issue on Mac M chips that currently doesn't compile at all because of compiler flags.

```elisp
(defun disaster--arch-flags ()
  "Select the right flags depending on the right architecture."
  (if ((lambda () "Optimize for M1 family if true"
         (and (eq system-type 'darwin)
              (string= "arm64" (string-trim (shell-command-to-string "uname -m"))))))
      "-mcpu=apple-m1"
    "-march=native"))
```

This is the function that select the right comp flag when starting disaster.